### PR TITLE
Use cross compiler, added automated cross compiler build script. Closes #67

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ kernel/o/
 *.swp
 *.d
 genInitrd/make_initrd
+cross/

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -12,6 +12,9 @@ Needed packages
     ISL (optional)
     CLooG (optional)
 
+    wget (yes, there are systems that don't have it)
+    tar (in case there are systems that don't have this too...)
+
 For Mac users:
 If you use OS X 10.7 or older you need to install gcc and do this:
 

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -12,8 +12,8 @@ Needed packages
     ISL (optional)
     CLooG (optional)
 
-    wget (yes, there are systems that don't have it)
-    tar (in case there are systems that don't have this too...)
+    tar
+    lzip
 
 For Mac users:
 If you use OS X 10.7 or older you need to install gcc and do this:

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -1,0 +1,43 @@
+To compile Q-OS you need to compile a cross compiler.
+
+Needed packages
+---------------
+
+    gcc 5.x
+    g++ 5.x
+    GNU Make
+    GNU Bison
+    Flex
+    Texinfo
+    ISL (optional)
+    CLooG (optional)
+
+For Mac users:
+If you use OS X 10.7 or older you need to install gcc and do this:
+
+    # This is only necessary for OS X users running 10.7 or below.
+    export CC=/usr/bin/gcc-5.X
+    export CXX=/usr/bin/g++-5.X
+    export CPP=/usr/bin/cpp-5.X
+    export LD=/usr/bin/gcc-5.X
+
+note: don't make these permanent
+
+Installing
+----------
+Run build_cross_compiler.sh script.
+After it's finished run:
+
+    . ./set_path.sh
+
+Note: you need to do that every time you start new console sessioi. Or permanently change your $PATH.
+
+Compiling Q-OS
+--------------
+To compile:
+
+    make
+
+To compile and run:
+
+    make qemu

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -30,7 +30,7 @@ After it's finished run:
 
     . ./set_path.sh
 
-Note: you need to do that every time you start new console sessioi. Or permanently change your $PATH.
+Note: you need to do that every time you start new console session. Or permanently change your $PATH.
 
 Compiling Q-OS
 --------------

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,16 @@
 ASM:=nasm
 #ASM flags
 ASMFLAGS:=-f elf32
+LD:=i686-elf-ld
 
 #C compiler
-CC:=gcc
+CC:=i686-elf-gcc
 #C compiler flags
 WARNINGS:=-Wall -Wextra #-pedantic -Wshadow -Wpointer-arith -Wcast-align \
             #-Wwrite-strings -Wmissing-prototypes -Wmissing-declarations \
             #-Wredundant-decls -Wnested-externs -Winline -Wno-long-long \
             #-Wuninitialized -Wconversion -Wstrict-prototypes -Werror
-CFLAGS:=-m32 -ffreestanding -std=c99 -Werror -pedantic $(WARNINGS)
+CFLAGS:=-ffreestanding -std=c99 -Werror -pedantic $(WARNINGS)
 #object file directory
 
 ODIR:=kernel/o
@@ -54,7 +55,7 @@ $(ISO): $(KERNEL) $(INITRD)
 
 $(KERNEL): $(CSOURCES) $(ASOURCES) $(COBJECTS) $(AOBJECTS)
 	@mkdir -p $(IMGDIR)/boot/
-	@ld -m elf_i386 -T $(DIR)/link.ld $(AOBJECTS) $(COBJECTS) -o $(IMGDIR)/boot/$@
+	@$(LD) -m elf_i386 -T $(DIR)/link.ld $(AOBJECTS) $(COBJECTS) -o $(IMGDIR)/boot/$@
 
 $(INITRD):
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ INITRD:=initrd.img
 GENINITRD_DIR:=genInitrd
 #note: this should be replaced with something better
 INITRD_REMOVE:=./make_initrd ./make_initrd.c ./initrd.img ./README.md
-INITRD_CONTENT:=$(filter-out $(INITRD_REMOVE),$(shell cd $(GENINITRD_DIR); find -type f))
+INITRD_CONTENT:=$(filter-out $(INITRD_REMOVE),$(shell cd $(GENINITRD_DIR); find . -type f))
 GENINITRD_ARGS:=$(foreach file,$(INITRD_CONTENT),$(patsubst ./%,%,$(file)) $(patsubst ./%,%,$(file)))
 
 -include $(DEPFILES)
@@ -64,7 +64,7 @@ $(INITRD):
 	@cp $(GENINITRD_DIR)/initrd.img $(IMGDIR)/boot/
 
 %.o: %.c Makefile
-	@$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
+	$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
 
 %.ao: %.asm
 	$(ASM) $(ASMFLAGS) -o $@ $<

--- a/build-cross-compiler.sh
+++ b/build-cross-compiler.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 mkdir cross
 cd cross
@@ -10,7 +11,7 @@ export PATH="$PREFIX/bin:$PATH"
 echo $PREFIX $TARGET $PATH
 
 BINUTILS_VER="binutils-2.25.1"
-wget http://ftp.gnu.org/gnu/binutils/$BINUTILS_VER.tar.bz2
+curl -o $BINUTILS_VER.tar.bz2 http://ftp.gnu.org/gnu/binutils/$BINUTILS_VER.tar.bz2
 tar -xvf $BINUTILS_VER.tar.bz2
 mkdir build-binutils
 cd build-binutils
@@ -24,19 +25,17 @@ MPFR_VER="mpfr-3.1.3"
 MPC_VER="mpc-1.0.3"
 GCC_VER="gcc-5.3.0"
 #prepare GCC for installation
-wget https://gmplib.org/download/gmp/$GMP_VER.tar.lz
-wget http://www.mpfr.org/mpfr-current/$MPFR_VER.tar.gz
-wget ftp://ftp.gnu.org/gnu/mpc/$MPC_VER.tar.gz
+curl -o $GMP_VER.tar.lz https://gmplib.org/download/gmp/$GMP_VER.tar.lz
+curl -o $MPFR_VER.tar.gz http://www.mpfr.org/mpfr-current/$MPFR_VER.tar.gz
+curl -o $MPC_VER.tar.gz ftp://ftp.gnu.org/gnu/mpc/$MPC_VER.tar.gz
 tar --lzip -xvf $GMP_VER.tar.lz
 tar -xvf $MPFR_VER.tar.gz
 tar -xvf $MPC_VER.tar.gz
-wget ftp://ftp.gnu.org/gnu/gcc/gcc-5.3.0/$GCC_VER.tar.gz
+curl -o $GCC_VER.tar.gz ftp://ftp.gnu.org/gnu/gcc/gcc-5.3.0/$GCC_VER.tar.gz
 tar -xvf $GCC_VER.tar.gz
 mv $GMP_VER $GCC_VER/gmp
 mv $MPFR_VER $GCC_VER/mpfr
 mv $MPC_VER $GCC_VER/mpc
-
-which -- $TARGET-as || echo $TARGET-as is not in the PATH
 
 mkdir build-gcc
 cd build-gcc

--- a/build-cross-compiler.sh
+++ b/build-cross-compiler.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+mkdir cross
+cd cross
+
+export PREFIX="$(pwd)"
+export TARGET="i686-elf"
+export PATH="$PREFIX/bin:$PATH"
+
+echo $PREFIX $TARGET $PATH
+
+BINUTILS_VER="binutils-2.25.1"
+wget http://ftp.gnu.org/gnu/binutils/$BINUTILS_VER.tar.bz2
+tar -xvf $BINUTILS_VER.tar.bz2
+mkdir build-binutils
+cd build-binutils
+../$BINUTILS_VER/configure --target=$TARGET --prefix="$PREFIX" --with-sysroot --disable-nls --disable-werror
+make -j4
+make install
+cd ..
+
+GMP_VER="gmp-6.1.0"
+MPFR_VER="mpfr-3.1.3"
+MPC_VER="mpc-1.0.3"
+GCC_VER="gcc-5.3.0"
+#prepare GCC for installation
+wget https://gmplib.org/download/gmp/$GMP_VER.tar.lz
+wget http://www.mpfr.org/mpfr-current/$MPFR_VER.tar.gz
+wget ftp://ftp.gnu.org/gnu/mpc/$MPC_VER.tar.gz
+tar --lzip -xvf $GMP_VER.tar.lz
+tar -xvf $MPFR_VER.tar.gz
+tar -xvf $MPC_VER.tar.gz
+wget ftp://ftp.gnu.org/gnu/gcc/gcc-5.3.0/$GCC_VER.tar.gz
+tar -xvf $GCC_VER.tar.gz
+mv $GMP_VER $GCC_VER/gmp
+mv $MPFR_VER $GCC_VER/mpfr
+mv $MPC_VER $GCC_VER/mpc
+
+which -- $TARGET-as || echo $TARGET-as is not in the PATH
+
+mkdir build-gcc
+cd build-gcc
+../$GCC_VER/configure --target=$TARGET --prefix="$PREFIX" --disable-nls --enable-languages=c,c++ --without-headers
+make -j4 all-gcc
+make -j4 all-target-libgcc
+make install-gcc
+make install-target-libgcc

--- a/set_path.sh
+++ b/set_path.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+contains() {
+    string="$1"
+    substring="$2"
+    if test "${string#*$substring}" != "$string"
+    then
+        return 0    # $substring is in $string
+    else
+        return 1    # $substring is not in $string
+    fi
+}
+
+cd cross
+export PREFIX="$(pwd)"
+export TARGET="i686-elf"
+export ADD_PATH="$PREFIX/bin"
+if ! contains $PATH  $ADD_PATH
+then
+    export PATH="$ADD_PATH:$PATH"
+    echo "PATH set to $PATH"
+else
+    echo "Path already set"
+fi
+cd ..


### PR DESCRIPTION
Should work on linux and mac.
To avoid rewriting all asm files nasm is still used.
